### PR TITLE
マイグレーションファイルの作成、アソシエーションの設定

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,0 +1,2 @@
+class Community < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,9 @@
 class User < ApplicationRecord
   validates :account, presence: true, uniqueness: { case_sensitive: false }
+  has_many :articles
+  has_one :user_detail
+
+  has_many :user_communities
+  has_many :communities, through: :user_communities
+  # belongs_to :user #belongs_toは何かしらに属するという意味になる
 end

--- a/app/models/user_community.rb
+++ b/app/models/user_community.rb
@@ -1,0 +1,5 @@
+class UserCommunity < ApplicationRecord
+  belongs_to :user
+  belongs_to :community
+end
+

--- a/app/models/user_detail.rb
+++ b/app/models/user_detail.rb
@@ -1,0 +1,3 @@
+class UserDetail < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20230714083200_add_user_id_to_articles.rb
+++ b/db/migrate/20230714083200_add_user_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :articles, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20230714085252_create_user_details.rb
+++ b/db/migrate/20230714085252_create_user_details.rb
@@ -1,0 +1,11 @@
+class CreateUserDetails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_details do |t|
+      t.datetime :birthday
+      t.string :phone_number
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230714090651_create_communities.rb
+++ b/db/migrate/20230714090651_create_communities.rb
@@ -1,0 +1,9 @@
+class CreateCommunities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :communities do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230714090746_create_user_communities.rb
+++ b/db/migrate/20230714090746_create_user_communities.rb
@@ -1,0 +1,10 @@
+class CreateUserCommunities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_communities do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :community, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_13_030640) do
+ActiveRecord::Schema.define(version: 2023_07_14_090746) do
 
   create_table "articles", charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "communities", charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_communities", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "community_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["community_id"], name: "index_user_communities_on_community_id"
+    t.index ["user_id"], name: "index_user_communities_on_user_id"
+  end
+
+  create_table "user_details", charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "birthday"
+    t.string "phone_number"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_details_on_user_id"
   end
 
   create_table "users", charset: "utf8mb3", force: :cascade do |t|
@@ -27,4 +53,8 @@ ActiveRecord::Schema.define(version: 2023_07_13_030640) do
     t.string "email"
   end
 
+  add_foreign_key "articles", "users"
+  add_foreign_key "user_communities", "communities"
+  add_foreign_key "user_communities", "users"
+  add_foreign_key "user_details", "users"
 end


### PR DESCRIPTION
## 概要

マイグレーションファイルの作成

アソシエーションの設定
- userとarticleを１対多に設定した
- userとuser_detailsを１対１に設定した
- userとcommunitiesを多対多に設定した
- userとcommunitiesの中間ファイルとしてuser_communitiesを作成し、userとuser_communitiesを１対多に設定し、communitiesとuser_communitiesを１対多に設定した